### PR TITLE
categories_id を category_id に rename

### DIFF
--- a/db/migrate/20210203235630_rename_categories_id_column_to_ideas.rb
+++ b/db/migrate/20210203235630_rename_categories_id_column_to_ideas.rb
@@ -1,0 +1,5 @@
+class RenameCategoriesIdColumnToIdeas < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :ideas, :categories_id, :category_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_03_024237) do
+ActiveRecord::Schema.define(version: 2021_02_03_235630) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,11 +24,11 @@ ActiveRecord::Schema.define(version: 2021_02_03_024237) do
 
   create_table "ideas", force: :cascade do |t|
     t.text "body", null: false
-    t.bigint "categories_id", null: false
+    t.bigint "category_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["categories_id"], name: "index_ideas_on_categories_id"
+    t.index ["category_id"], name: "index_ideas_on_category_id"
   end
 
-  add_foreign_key "ideas", "categories", column: "categories_id"
+  add_foreign_key "ideas", "categories"
 end


### PR DESCRIPTION
## 概要
- Idea テーブルのカラム名のスペルが間違っていたので修正
- categories_id から category_id へ rename